### PR TITLE
feat: Implement admin login functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env
+cookies.txt
+server.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.2",
         "drizzle-orm": "^0.39.3",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4403,6 +4404,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "NODE_ENV=development tsx --env-file .env server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
@@ -48,6 +48,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.2",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/db.ts
+++ b/server/db.ts
@@ -4,39 +4,14 @@ import * as schema from "@shared/schema";
 
 // Aiven PostgreSQL configuration
 const config = {
-  user: "avnadmin",
-  password: "AVNS_ybNeXKZAZjVc2vpPU_v",
-  host: "pg-2dc30e27-sccau.i.aivencloud.com",
-  port: 11319,
-  database: "defaultdb",
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  database: process.env.DB_NAME,
   ssl: {
     rejectUnauthorized: true,
-    ca: `-----BEGIN CERTIFICATE-----
-MIIEUDCCArigAwIBAgIUfABmt1KIqyySe9goPWcM0DS4gMYwDQYJKoZIhvcNAQEM
-BQAwQDE+MDwGA1UEAww1MmU3OTcwNTctNWRlNS00YjA3LWJhNmEtMDBmYWU0NjY0
-NDljIEdFTiAxIFByb2plY3QgQ0EwHhcNMjUwODI0MDQzNTUyWhcNMzUwODIyMDQz
-NTUyWjBAMT4wPAYDVQQDDDUyZTc5NzA1Ny01ZGU1LTRiMDctYmE2YS0wMGZhZTQ2
-NjQ0OWMgR0VOIDEgUHJvamVjdCBDQTCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCC
-AYoCggGBAJ5lahHlh/gK3xB/IHCuvkOQnhldsD0ypCqABH+tVuwTn+KYAeCBazEj
-hHhH2WWWd61Y/P2C975O+YCQHcUb/2Uxl/5TQoj7bOMHxa1+/e0sJ0HQhcj5yJ2O
-zVIEY8dBglrh12SeF9ySn6j5Dse/dE6ZL9cNjRgc2/pRid3uZWC4ayo7MXUvhEcd
-oHZOICrF4D8sER6dVkoYBsC/17TdEcfmuGMGbhssTqMMfkr52b2diRUKDq5xv5DB
-Ts/eVj9fZ+49CMc8i+3wLV+ltN03UNQntqpUfUf5N2QqOVmZualdpSm56uWph4Sw
-jLczIpqmP9w/QgvAZuJcZs6BJ2kcJqzwjqLGoOnP9KKq1+03Ew2dAppa89bRk4Vi
-gprjYUmjt36lIPx97WS8ra91Ricpn5ees3rHEbwIiEo0y0kPtEtvZKOpqI1OoTjN
-pH50eumaW3FrduZgT5N860tsh6sb4PawxkdgS3dVxuBxuS0VoFYzv9YxXLT0W2ak
-ochCX9tI2wIDAQABo0IwQDAdBgNVHQ4EFgQUnMEgHVIq0HhU3VIYb2+msB/WGEsw
-EgYDVR0TAQH/BAgwBgEB/wIBADALBgNVHQ8EBAMCAQYwDQYJKoZIhvcNAQEMBQAD
-ggGBAGldnuKbh8F2c5pTZr2v9UZvg2x0s2m7h7XPspRCtNqj3zrKeXZfzU3ItDhO
-+r0tTtiBfMFLtgRyEAEV2OrliszCcM1VopLRrqGHN+Aa2WUN+dhth6OULvPUPLFV
-U5bUu1P5mhk0DdnzT71UbS9BRD8m6sifR5r77vbt1B+WcfkYUrLR7olz0ivUg6z+
-zhGIWlafGJII2b87QZ7b0bQczpP0VxD8+rCxGcyO9Dl9C2cbWawqKTtB8ZhQAouK
-XuAD0Pr+f6pLGCyu6Znjnz3p41eJnbz47aGyRRD2kbEHVfAUojNrMLjauEYUeSEd
-7NqmuDj694rb48I0NZkUWLvnCbzzc5ZmEQq1ZwDuA8PvuqWv+wUb8pAVOWfygOXQ
-v/cWZmdBBtLcP8v7k6ThPbfaqe/txVXvFOajCwmAVW6cGwZ2NDY2+UKpoNC6RJNF
-qquvaRqgqFmA7kz4DO5MSXVD6iiFUhc07N9jRWVqNCp+uAH1Ht2CLLOBs2fEnqqM
-wQEiAw==
------END CERTIFICATE-----`,
+    ca: process.env.DB_CERT,
   },
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,5 @@
+import dotenv from "dotenv";
+dotenv.config();
 import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import MemoryStore from "memorystore";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -124,6 +124,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     next();
   };
 
+  app.post("/api/admin/login", async (req, res) => {
+    const { password } = req.body;
+    if (password === process.env.ADMIN_PASSWORD) {
+      if (req.session) {
+        req.session.isAdmin = true;
+      }
+      res.json({ message: "Login successful" });
+    } else {
+      res.status(401).json({ message: "Invalid credentials" });
+    }
+  });
+
   app.use("/api/admin", requireAdmin);
 
   app.get("/api/admin/schools", async (req, res) => {


### PR DESCRIPTION
This commit introduces the admin login functionality.

- Adds a new `/api/admin/login` endpoint to handle admin authentication.
- Externalizes database credentials and other secrets to a `.env` file.
- Uses the `dotenv` package to load environment variables.
- Refactors the database connection to use environment variables instead of hardcoded values.
- Updates `.gitignore` to exclude the `.env` file and other temporary files.