### PR TITLE
fix: Ensure environment variables are loaded robustly at startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.2",
         "drizzle-orm": "^0.39.3",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4403,6 +4404,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx --env-file .env server/index.ts",
+    "dev": "NODE_ENV=development tsx --require ./server/dotenv.ts server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
@@ -48,6 +48,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.2",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/dotenv.ts
+++ b/server/dotenv.ts
@@ -1,0 +1,1 @@
+import 'dotenv/config';


### PR DESCRIPTION
This commit fixes a persistent bug where environment variables from the .env file were not being loaded correctly, causing the application to fail to connect to the database.

This new approach uses the `--require` flag from `tsx` to preload a script that configures `dotenv`. This guarantees that environment variables are loaded before any other application code is executed, which is a more robust solution than relying on import order or the `--env-file` flag which was not working reliably in the user's environment.

- Re-installs the `dotenv` package.
- Creates a `server/dotenv.ts` file to handle the `dotenv` configuration.
- Modifies the `dev` script in `package.json` to use `tsx --require ./server/dotenv.ts server/index.ts`.