### PR TITLE
Fix client-side routing on Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,6 @@
   },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
-    { "source": "/((?!api|.*\\..*).*)", "destination": "/" }
+    { "source": "/((?!api|.*\\..*).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Purpose

The user deployed their Node.js Vite application to Vercel but encountered an issue where only the homepage was accessible. When navigating to other routes like `/dashboard`, Vercel returned 404 errors because it was looking for static files at those paths instead of serving the SPA. The goal was to configure Vercel to properly handle client-side routing by redirecting all non-API requests to the main application entry point.

## Code changes

Updated the `vercel.json` configuration file to fix the rewrite rule destination:
- Changed the catch-all route destination from `"/"` to `"/index.html"`
- This ensures that all non-API requests are properly served the main HTML file, allowing the client-side router to handle navigation

The change allows the single-page application to function correctly on Vercel by ensuring all routes are served through the main `index.html` file.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/19c55274d4924edab36ab7c1f2499365/mystic-hub)

👀 [Preview Link](https://19c55274d4924edab36ab7c1f2499365-mystic-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19c55274d4924edab36ab7c1f2499365</projectId>-->
<!--<branchName>mystic-hub</branchName>-->